### PR TITLE
Update README Deps Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`
+    * **Note:** the dependency on [letter_lines_elixir](https://github.com/adam-phillips/letter_lines_elixir) is currently set using a local path as it's not published.
   * Create and migrate your database with `mix ecto.setup`
   * Install Node.js dependencies with `npm install` inside the `assets` directory
   * Start Phoenix endpoint with `mix phx.server`


### PR DESCRIPTION
Include a note in the README about the `letter_lines_elixir` dep not being a published library, so it needs to exist locally to use the path set in `mix.exs`