### PR TITLE
Handle displaying revealed words and tiles

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -6,12 +6,20 @@ rect.board-background {
   fill: grey;
 }
 
+rect.available-letters-background {
+  fill: grey;
+}
+
 rect.hidden-letter-tile {
   fill: black;
 }
 
 rect.exposed-letter-tile {
   fill: white;
+}
+
+text.exposed-letter {
+  fill: black;
 }
 
 /* LiveView specific classes for your customizations */

--- a/lib/letter_lines_live_web/live/page_live.ex
+++ b/lib/letter_lines_live_web/live/page_live.ex
@@ -87,7 +87,7 @@ defmodule LetterLinesLiveWeb.PageLive do
   @impl Phoenix.LiveView
   def handle_event("guess", %{"submit_word" => %{"word_guess" => guess}}, %{assigns: %{game: game}} = socket) do
     game =
-      case BoardState.reveal_word(game.board_state, guess) |> IO.inspect() do
+      case BoardState.reveal_word(game.board_state, guess) do
         {:ok, %BoardState{} = board_state} -> %GameState{game | board_state: board_state}
         {:error, :nothing_revealed} -> game
       end

--- a/lib/letter_lines_live_web/live/page_live.html.leex
+++ b/lib/letter_lines_live_web/live/page_live.html.leex
@@ -8,5 +8,19 @@
   %>
 </svg>
 <br />
+<br />
+<svg width="<%= available_letters_width(assigns) %>" height="<%= available_letters_height(assigns) %>">
+  <rect width="<%= available_letters_width(assigns) %>" height="<%= available_letters_height(assigns) %>"
+    class="available-letters-background" />
+  <%=
+    for x_index <- 0..(length(@available_letters) - 1) do
+      display_available_letters(assigns, x_index)
+    end
+  %>
+</svg>
+<%= f = form_for :submit_word, "#", phx_submit: :guess %>
+<%= text_input f, :word_guess %>
+<%= submit "Guess" %>
+</form>
+
 <%= inspect @game %>
-<!-- TODO: Determine math for displaying blank tile or letter tile and letter  -->

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule LetterLinesLive.MixProject do
       {:jason, "~> 1.0"},
       # Mix app that houses base game logic and functionality. Unpublished, so using ref from GitHub
       {:letter_lines_elixir,
-       github: "adam-phillips/letter_lines_elixir", ref: "20b542b9af174c84d87e68de9ed1debf10a7f71f"},
+       github: "adam-phillips/letter_lines_elixir", ref: "03ac93049b7a31d72650ef0dafdacc82737a7221"},
       # Continuous test running
       {:mix_test_watch, "~> 1.0.2", only: :dev, runtime: false},
       # Mocking services for tests

--- a/mix.lock
+++ b/mix.lock
@@ -21,7 +21,7 @@
   "html_entities": {:hex, :html_entities, "0.5.1", "1c9715058b42c35a2ab65edc5b36d0ea66dd083767bef6e3edb57870ef556549", [:mix], [], "hexpm", "30efab070904eb897ff05cd52fa61c1025d7f8ef3a9ca250bc4e6513d16c32de"},
   "idna": {:hex, :idna, "6.0.1", "1d038fb2e7668ce41fbf681d2c45902e52b3cb9e9c77b55334353b222c2ee50c", [:rebar3], [{:unicode_util_compat, "0.5.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "a02c8a1c4fd601215bb0b0324c8a6986749f807ce35f25449ec9e69758708122"},
   "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
-  "letter_lines_elixir": {:git, "https://github.com/adam-phillips/letter_lines_elixir.git", "20b542b9af174c84d87e68de9ed1debf10a7f71f", [ref: "20b542b9af174c84d87e68de9ed1debf10a7f71f"]},
+  "letter_lines_elixir": {:git, "https://github.com/adam-phillips/letter_lines_elixir.git", "03ac93049b7a31d72650ef0dafdacc82737a7221", [ref: "03ac93049b7a31d72650ef0dafdacc82737a7221"]},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm", "6cbe761d6a0ca5a31a0931bf4c63204bceb64538e664a8ecf784a9a6f3b875f1"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},


### PR DESCRIPTION
Add styling to differentiate exposed tiles. Include logic for a form
for entering guesses, then revealing the guessed word if on the board.
Also add logic for displaying available letters in preparation for
clicking letters for input as opposed to keying into a text field.